### PR TITLE
Drop the first output after spawning bash

### DIFF
--- a/langchain_contrib/tools/terminal/terminal.py
+++ b/langchain_contrib/tools/terminal/terminal.py
@@ -57,6 +57,8 @@ class Terminal(BaseModel):
         os.environ["PS1"] = bash_prompt
         sh = pexpect.spawn("/bin/bash --norc", encoding="utf-8")
         time.sleep(init_delay)
+        sh.read_nonblocking(size=output_size)
+        sh.sendline('')
         bash_prompt = sh.read_nonblocking(size=output_size)
         super().__init__(
             refresh_interval=refresh_interval,


### PR DESCRIPTION
Fix: #28 